### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-alpine
+
+WORKDIR /usr/src/app
+
+RUN apk update
+RUN apk add py3-numpy py3-pandas
+ENV PYTHONPATH=/usr/lib/python3.11/site-packages
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENTRYPOINT ["python", "pyTick_cli.py"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -68,3 +68,17 @@ pandas 1.3.4
 
 2. Clone the repository and run the script inside of the repo directory.
 CSV files uploads were tested ONLY on the script main directory, so paste them there to guarantee that it will run.
+
+### Docker
+
+To run in Docker, build with e.g.:
+
+```
+docker build -t pytick .
+```
+
+and run with e.g.:
+
+```
+docker run -it --rm -v /path/to/dir/.env:/usr/src/app/.env pytick info
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+python-dotenv
+docopt
+pandas
+requests


### PR DESCRIPTION
I added a `Dockerfile` so I could run this without installing Python on my host system; opening a PR in case others find it useful.

Also added the dependencies needed to a `requirements.txt` file; in the `Dockerfile` a couple packages are also installed with `apk` to avoid the need to build wheels in the minimal Alpine image.